### PR TITLE
Make the Hibernate variants match the Spring Data variants

### DIFF
--- a/src/test/java/com/example/demo/HibernateEmbeddedIdTests.java
+++ b/src/test/java/com/example/demo/HibernateEmbeddedIdTests.java
@@ -2,6 +2,7 @@ package com.example.demo;
 
 import com.example.demo.EmbeddedId.CustomerWithEmbedId;
 import com.example.demo.EmbeddedId.VipCustomerWithEmbedId;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,6 +38,15 @@ class HibernateEmbeddedIdTests {
 
     @Autowired
     TransactionTemplate txTemplate;
+
+    @BeforeEach
+    void setup() {
+
+        txTemplate.executeWithoutResult(tx -> {
+            entityManager.createQuery("delete from VipCustomerWithEmbedId").executeUpdate();
+            entityManager.createQuery("delete from VipCustomerWithIdClass").executeUpdate();
+        });
+    }
 
     @Test
     void embeddedIdWithoutTransaction() {

--- a/src/test/java/com/example/demo/HibernateEmbeddedIdTests.java
+++ b/src/test/java/com/example/demo/HibernateEmbeddedIdTests.java
@@ -1,6 +1,5 @@
 package com.example.demo;
 
-import com.example.demo.EmbeddedId.CustomerWithEmbedId;
 import com.example.demo.EmbeddedId.VipCustomerWithEmbedId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import javax.persistence.EntityManager;
+import java.util.function.Function;
 
 @SpringBootTest
 @Testcontainers
@@ -50,15 +50,25 @@ class HibernateEmbeddedIdTests {
 
     @Test
     void embeddedIdWithoutTransaction() {
-        doStuff();
+        doStuff(entityManager);
+    }
+
+    @Test
+    void embeddedIdWithInnerTransaction() {
+        doStuff(e -> txTemplate.execute(tx -> entityManager.merge(e)));
     }
 
     @Test
     void embeddedIdWithTransaction() {
-        txTemplate.execute(status -> doStuff());
+        txTemplate.execute(status -> doStuff(entityManager));
     }
 
-    private VipCustomerWithEmbedId doStuff() {
+    private VipCustomerWithEmbedId doStuff(EntityManager em) {
+        return doStuff(e -> em.merge(e));
+    }
+
+    private VipCustomerWithEmbedId doStuff(Function<VipCustomerWithEmbedId, VipCustomerWithEmbedId> mergeOperation) {
+
 //        CustomerWithEmbedId customer = new CustomerWithEmbedId("a", "b");
 //        customer.setVersionId(123L);
 //        customer.setUnitId(456L);
@@ -72,10 +82,10 @@ class HibernateEmbeddedIdTests {
         vipCustomer.setVersionId(987L);
         vipCustomer.setUnitId(654L);
 
-        vipCustomer = entityManager.merge(vipCustomer); //save object of subclass, ok
+        vipCustomer = mergeOperation.apply(vipCustomer); //save object of subclass, ok
 
         vipCustomer.setVipNumber("999");
-        vipCustomer = entityManager.merge(vipCustomer);//modify object of subclass and save again, ok
+        vipCustomer = mergeOperation.apply(vipCustomer);//modify object of subclass and save again, ok
         // using embedded id annotation, all 4 times of saving to db ok, for both pg and mysql
 
         return vipCustomer;

--- a/src/test/java/com/example/demo/HibernateIdClassTests.java
+++ b/src/test/java/com/example/demo/HibernateIdClassTests.java
@@ -61,6 +61,11 @@ class HibernateIdClassTests {
 	}
 
 	@Test
+	void idClassWithInnerTransaction() {
+		doStuff(e -> txTemplate.execute(tx -> entityManager.merge(e)));
+	}
+
+	@Test
 	void idClassWithHandRolledTransaction() {
 
 		EntityManager em = entityManagerFactory.createEntityManager();

--- a/src/test/java/com/example/demo/HibernateIdClassTests.java
+++ b/src/test/java/com/example/demo/HibernateIdClassTests.java
@@ -1,16 +1,13 @@
 package com.example.demo;
 
-import com.example.demo.IdClass.CustomerPK;
-import com.example.demo.IdClass.CustomerWithIdClass;
 import com.example.demo.IdClass.VipCustomerWithIdClass;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionCallback;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -19,65 +16,79 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
+import java.util.function.Function;
 
 @SpringBootTest
 @Testcontainers
 class HibernateIdClassTests {
 
-    @Container
-    static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
-        .withDatabaseName("demo")
-        .withUsername("postgres")
-        .withPassword("password");
+	@Container
+	static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
+			.withDatabaseName("demo")
+			.withUsername("postgres")
+			.withPassword("password");
 
-    @DynamicPropertySource
-    static void postgresProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-    }
+	@DynamicPropertySource
+	static void postgresProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", database::getJdbcUrl);
+		registry.add("spring.datasource.username", database::getUsername);
+		registry.add("spring.datasource.password", database::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+	}
 
 
-    @Autowired
-    EntityManager entityManager;
+	@Autowired
+	EntityManager entityManager;
 
-    @Autowired
-    TransactionTemplate txTemplate;
+	@Autowired
+	TransactionTemplate txTemplate;
 
-    @Autowired
-    EntityManagerFactory entityManagerFactory;
+	@Autowired
+	EntityManagerFactory entityManagerFactory;
 
-    @Test
-    void idClassWithoutTransaction() {
-        doStuff(entityManager);
-    }
+	@BeforeEach
+	void setup() {
 
-    @Test
-    void idClassWithHandRolledTransaction() {
+		txTemplate.executeWithoutResult(tx -> {
+			entityManager.createQuery("delete from VipCustomerWithEmbedId").executeUpdate();
+			entityManager.createQuery("delete from VipCustomerWithIdClass").executeUpdate();
+		});
+	}
 
-        EntityManager em = entityManagerFactory.createEntityManager();
-        EntityTransaction tx = em.getTransaction();
+	@Test
+	void idClassWithoutTransaction() {
+		doStuff(entityManager);
+	}
 
-        tx.begin();
+	@Test
+	void idClassWithHandRolledTransaction() {
 
-        doStuff(em);
+		EntityManager em = entityManagerFactory.createEntityManager();
+		EntityTransaction tx = em.getTransaction();
 
-        tx.commit();
-    }
+		tx.begin();
 
-    @Test
-    void idClassWithTransaction() {
-        txTemplate.execute(status -> doStuff(entityManager));
-    }
+		doStuff(em);
 
-    @Test
-    @Transactional
-    void idClassWithTransactional() {
-        doStuff(entityManager);
-    }
+		tx.commit();
+	}
 
-    private VipCustomerWithIdClass doStuff(EntityManager em) {
+	@Test
+	void idClassWithTransaction() {
+		txTemplate.execute(status -> doStuff(entityManager));
+	}
+
+	@Test
+	@Transactional
+	void idClassWithTransactional() {
+		doStuff(entityManager);
+	}
+
+	private VipCustomerWithIdClass doStuff(EntityManager em) {
+		return doStuff(e -> em.merge(e));
+	}
+
+	private VipCustomerWithIdClass doStuff(Function<VipCustomerWithIdClass, VipCustomerWithIdClass> mergeOperation) {
 //        CustomerWithIdClass customer = new CustomerWithIdClass("a", "b");
 //        customer.setVersionId(123L);
 //        customer.setUnitId(456L);
@@ -87,18 +98,18 @@ class HibernateIdClassTests {
 //        customer.setFirstName("a2");
 //        customer = entityManager.merge(customer);//modify object of base class and merge again, ok
 
-        VipCustomerWithIdClass vipCustomer = new VipCustomerWithIdClass("a", "b", "888");
-        vipCustomer.setVersionId(987L);
-        vipCustomer.setUnitId(654L);
+		VipCustomerWithIdClass vipCustomer = new VipCustomerWithIdClass("a", "b", "888");
+		vipCustomer.setVersionId(987L);
+		vipCustomer.setUnitId(654L);
 
-        vipCustomer = em.merge(vipCustomer);//merge object of subclass, ok
+		vipCustomer = mergeOperation.apply(vipCustomer);//merge object of subclass, ok
 
-        vipCustomer.setVipNumber("999");
-        vipCustomer = em.merge(vipCustomer);//modify object of subclass and merge again, NOT OK
-        // ↑ THIS FAILS BECAUSE OF PRIMARY KEY CONFLICT. INSERT STATEMENT WAS USED INSTEAD OF UPDATE, WHY?
-        // this failure only happens when:
-        // 1. base class uses IdClass for composite primary key
-        // 2. saving an instance of the subclass for the second time after modification
-        return vipCustomer;
-    }
+		vipCustomer.setVipNumber("999");
+		vipCustomer = mergeOperation.apply(vipCustomer);//modify object of subclass and merge again, NOT OK
+		// ↑ THIS FAILS BECAUSE OF PRIMARY KEY CONFLICT. INSERT STATEMENT WAS USED INSTEAD OF UPDATE, WHY?
+		// this failure only happens when:
+		// 1. base class uses IdClass for composite primary key
+		// 2. saving an instance of the subclass for the second time after modification
+		return vipCustomer;
+	}
 }

--- a/src/test/java/com/example/demo/SpringDataEmbeddedIdTests.java
+++ b/src/test/java/com/example/demo/SpringDataEmbeddedIdTests.java
@@ -46,7 +46,7 @@ class SpringDataEmbeddedIdTests {
 	}
 
 	@Test
-	void embeddedIdWithoutTransaction() {
+	void embeddedIdWithInnerTransaction() {
 		doStuff();
 	}
 

--- a/src/test/java/com/example/demo/SpringDataEmbeddedIdTests.java
+++ b/src/test/java/com/example/demo/SpringDataEmbeddedIdTests.java
@@ -1,8 +1,8 @@
 package com.example.demo;
 
-import com.example.demo.EmbeddedId.CustomerWithEmbedId;
 import com.example.demo.EmbeddedId.CustomerWithEmbedIdRepository;
 import com.example.demo.EmbeddedId.VipCustomerWithEmbedId;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,37 +17,45 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 class SpringDataEmbeddedIdTests {
 
-    @Container
-    static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
-        .withDatabaseName("demo")
-        .withUsername("postgres")
-        .withPassword("password");
+	@Container
+	static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
+			.withDatabaseName("demo")
+			.withUsername("postgres")
+			.withPassword("password");
 
-    @DynamicPropertySource
-    static void postgresProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-    }
+	@DynamicPropertySource
+	static void postgresProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", database::getJdbcUrl);
+		registry.add("spring.datasource.username", database::getUsername);
+		registry.add("spring.datasource.password", database::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+	}
 
-    @Autowired
-    CustomerWithEmbedIdRepository repositoryEmbedIdVersion;
+	@Autowired
+	CustomerWithEmbedIdRepository repositoryEmbedIdVersion;
 
-    @Autowired
-    TransactionTemplate txTemplate;
+	@Autowired
+	TransactionTemplate txTemplate;
 
-    @Test
-    void embeddedIdWithoutTransaction() {
-        doStuff();
-    }
+	@BeforeEach
+	void setup() {
 
-    @Test
-    void embeddedIdWithTransaction() {
-        txTemplate.execute(status -> doStuff());
-    }
+		txTemplate.executeWithoutResult(tx -> {
+			repositoryEmbedIdVersion.deleteAll();
+		});
+	}
 
-    private VipCustomerWithEmbedId doStuff() {
+	@Test
+	void embeddedIdWithoutTransaction() {
+		doStuff();
+	}
+
+	@Test
+	void embeddedIdWithTransaction() {
+		txTemplate.execute(status -> doStuff());
+	}
+
+	private VipCustomerWithEmbedId doStuff() {
 //        CustomerWithEmbedId customer = new CustomerWithEmbedId("a", "b");
 //        customer.setVersionId(123L);
 //        customer.setUnitId(456L);
@@ -57,16 +65,16 @@ class SpringDataEmbeddedIdTests {
 //        customer.setFirstName("a2");
 //        customer = repositoryEmbedIdVersion.save(customer);//modify object of base class and save again, ok
 
-        VipCustomerWithEmbedId vipCustomer = new VipCustomerWithEmbedId("a", "b", "888");
-        vipCustomer.setVersionId(987L);
-        vipCustomer.setUnitId(654L);
+		VipCustomerWithEmbedId vipCustomer = new VipCustomerWithEmbedId("a", "b", "888");
+		vipCustomer.setVersionId(987L);
+		vipCustomer.setUnitId(654L);
 
-        vipCustomer = repositoryEmbedIdVersion.save(vipCustomer); //save object of subclass, ok
+		vipCustomer = repositoryEmbedIdVersion.save(vipCustomer); //save object of subclass, ok
 
-        vipCustomer.setVipNumber("999");
-        vipCustomer = repositoryEmbedIdVersion.save(vipCustomer);//modify object of subclass and save again, ok
-        // using embedded id annotation, all 4 times of saving to db ok, for both pg and mysql
+		vipCustomer.setVipNumber("999");
+		vipCustomer = repositoryEmbedIdVersion.save(vipCustomer);//modify object of subclass and save again, ok
+		// using embedded id annotation, all 4 times of saving to db ok, for both pg and mysql
 
-        return vipCustomer;
-    }
+		return vipCustomer;
+	}
 }

--- a/src/test/java/com/example/demo/SpringDataIdClassTests.java
+++ b/src/test/java/com/example/demo/SpringDataIdClassTests.java
@@ -48,7 +48,7 @@ class SpringDataIdClassTests {
 	}
 
 	@Test
-	void idClassWithoutTransaction() {
+	void idClassWithInnerTransaction() {
 		doStuff();
 	}
 

--- a/src/test/java/com/example/demo/SpringDataIdClassTests.java
+++ b/src/test/java/com/example/demo/SpringDataIdClassTests.java
@@ -1,8 +1,8 @@
 package com.example.demo;
 
-import com.example.demo.IdClass.CustomerWithIdClass;
 import com.example.demo.IdClass.CustomerWithIdClassRepository;
 import com.example.demo.IdClass.VipCustomerWithIdClass;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,44 +18,52 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 class SpringDataIdClassTests {
 
-    @Container
-    static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
-        .withDatabaseName("demo")
-        .withUsername("postgres")
-        .withPassword("password");
+	@Container
+	static PostgreSQLContainer<?> database = new PostgreSQLContainer<>("postgres:9.6.12")
+			.withDatabaseName("demo")
+			.withUsername("postgres")
+			.withPassword("password");
 
-    @DynamicPropertySource
-    static void postgresProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", database::getJdbcUrl);
-        registry.add("spring.datasource.username", database::getUsername);
-        registry.add("spring.datasource.password", database::getPassword);
-        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
-    }
+	@DynamicPropertySource
+	static void postgresProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.datasource.url", database::getJdbcUrl);
+		registry.add("spring.datasource.username", database::getUsername);
+		registry.add("spring.datasource.password", database::getPassword);
+		registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+	}
 
 
-    @Autowired
-    CustomerWithIdClassRepository repositoryIdClassVersion;
+	@Autowired
+	CustomerWithIdClassRepository repositoryIdClassVersion;
 
-    @Autowired
-    TransactionTemplate txTemplate;
+	@Autowired
+	TransactionTemplate txTemplate;
 
-    @Test
-    void idClassWithoutTransaction() {
-        doStuff();
-    }
+	@BeforeEach
+	void setup() {
 
-    @Test
-    void idClassWithTransaction() {
-        txTemplate.execute(status -> doStuff());
-    }
+		txTemplate.executeWithoutResult(tx -> {
+			repositoryIdClassVersion.deleteAll();
+		});
+	}
 
-    @Test
-    @Transactional
-    void idClassWithTransactional() {
-        doStuff();
-    }
+	@Test
+	void idClassWithoutTransaction() {
+		doStuff();
+	}
 
-    private VipCustomerWithIdClass doStuff() {
+	@Test
+	void idClassWithTransaction() {
+		txTemplate.execute(status -> doStuff());
+	}
+
+	@Test
+	@Transactional
+	void idClassWithTransactional() {
+		doStuff();
+	}
+
+	private VipCustomerWithIdClass doStuff() {
 //        CustomerWithIdClass customer = new CustomerWithIdClass("a", "b");
 //        customer.setVersionId(123L);
 //        customer.setUnitId(456L);
@@ -65,19 +73,19 @@ class SpringDataIdClassTests {
 //        customer.setFirstName("a2");
 //        customer = repositoryIdClassVersion.save(customer);//modify object of base class and save again, ok
 
-        VipCustomerWithIdClass vipCustomer = new VipCustomerWithIdClass("a", "b", "888");
-        vipCustomer.setVersionId(987L);
-        vipCustomer.setUnitId(654L);
+		VipCustomerWithIdClass vipCustomer = new VipCustomerWithIdClass("a", "b", "888");
+		vipCustomer.setVersionId(987L);
+		vipCustomer.setUnitId(654L);
 
-        vipCustomer = repositoryIdClassVersion.save(vipCustomer);//save object of subclass, ok
+		vipCustomer = repositoryIdClassVersion.save(vipCustomer);//save object of subclass, ok
 
-        vipCustomer.setVipNumber("999");
-        vipCustomer = repositoryIdClassVersion.save(vipCustomer);//modify object of subclass and save again, NOT OK
-        // ↑ THIS FAILS BECAUSE OF PRIMARY KEY CONFLICT. INSERT STATEMENT WAS USED INSTEAD OF UPDATE, WHY?
-        // this failure only happens when:
-        // 1. base class uses IdClass for composite primary key
-        // 2. saving an instance of the subclass for the second time after modification
+		vipCustomer.setVipNumber("999");
+		vipCustomer = repositoryIdClassVersion.save(vipCustomer);//modify object of subclass and save again, NOT OK
+		// ↑ THIS FAILS BECAUSE OF PRIMARY KEY CONFLICT. INSERT STATEMENT WAS USED INSTEAD OF UPDATE, WHY?
+		// this failure only happens when:
+		// 1. base class uses IdClass for composite primary key
+		// 2. saving an instance of the subclass for the second time after modification
 
-        return vipCustomer;
-    }
+		return vipCustomer;
+	}
 }


### PR DESCRIPTION
1. Adds `setup` methods to clean the database between tests.
2. Introduces test variants with "inner transactions" that only wrap the merge calls, which is what Spring Data is doing.